### PR TITLE
Added screen-inhibit-control interface to the snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "win": {
       "target": "msi"
     },
+    "snap": {
+     "plugs": ["default", "screen-inhibit-control"]
+    },
     "linux": {
       "category": "Video",
       "target": [


### PR DESCRIPTION
This *should* allows the application to prevent the host from sleeping and locking during video playback. Should fix Issue #27.