### PR TITLE
[Build: Linux] Fix invalid download URL for CastLabs Electron

### DIFF
--- a/build/electron-builder.castlabs.yml
+++ b/build/electron-builder.castlabs.yml
@@ -1,0 +1,2 @@
+electronDownload:
+  mirror: https://github.com/castlabs/electron-releases/releases/download/v

--- a/package.linux.json
+++ b/package.linux.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron .",
     "test": "echo 'TODO: Tests'",
-    "build": "electron-builder -c ./build/electron-builder.yml -p never"
+    "build": "electron-builder -c build/electron-builder.yml -c build/electorn-builder.castlabs.yml -p never"
   },
   "repository": "https://github.com/oscartbeaumont/ElectronPlayer.git",
   "author": "Oscar Beaumont <oscar@otbeaumont.me> (https://otbeaumont.me)",


### PR DESCRIPTION
Hey there,

while packaging ElectronPlayer on the AUR today I saw that for some reason `electron-builder` now tries to download the wrong electron binaries. 

This PR fixes this issue by adding a second electron-builder config (called `electron-builder.castlabs.yml` that can be included alongside the original one for the Linux build.

By creating an *incremental config* we avoid duplicated config files like with the unfortunate package.json situation.

**Note**: 
The `v` at the end of the custom URL is needed, as CastLabs puts a "v" in front of the git version tags. 
See [CastLabs](https://github.com/castlabs/electron-releases/tags)
See [Electron Downloader docs](https://github.com/electron/get#specifying-a-mirror)

P.S. This should also fix the failing Travis build as it has the same issue I had before.