### PR TITLE
feat(options): force external links with target="_blank" to open internally in current window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -198,6 +198,12 @@ async function createWindow() {
   // Inject Header Script On Page Load If In Frameless Window
   mainWindow.webContents.on('dom-ready', broswerWindowDomReady);
 
+  // Force links with target="_blank" to open internally (in current window)
+  mainWindow.webContents.on('new-window', (e, url) => {
+    e.preventDefault();
+    mainWindow.loadURL(url);
+  });
+
   // Emitted when the window is closed.
   mainWindow.on('closed', mainWindowClosed);
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -196,6 +196,16 @@ module.exports = (store, services, mainWindow, app, defaultUserAgent) => {
             : false
         },
         {
+          label: 'Force Open Links Internally',
+          type: 'checkbox',
+          click(e) {
+            store.set('options.openLinksInternally', e.checked);
+          },
+          checked: store.get('options.openLinksInternally')
+          ? store.get('options.openLinksInternally')
+          : false
+        },
+        {
           label: 'Enabled Services',
           submenu: enabledServicesMenuItems
         },


### PR DESCRIPTION
I added this simple feature because for some sites like https://bilibili.com, it'll create a new window instance on every link click. Now every link click will load that URL into current window which should be the desired behavior of a desktop app.

fix #105