### PR TITLE
feat(options): add an option to force all links to open in current window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -195,6 +195,14 @@ async function createWindow() {
     }
   });
 
+  // Force links with target="_blank" to open internally (in current window)
+  if (store.get('options.openLinksInternally')) {
+    mainWindow.webContents.on('new-window', (e, url) => {
+      e.preventDefault();
+      mainWindow.loadURL(url);
+    });
+  }
+
   // Inject Header Script On Page Load If In Frameless Window
   mainWindow.webContents.on('dom-ready', broswerWindowDomReady);
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -196,6 +196,16 @@ module.exports = (store, services, mainWindow, app, defaultUserAgent) => {
             : false
         },
         {
+          label: 'Force Open Links Internally',
+          type: 'checkbox',
+          click(e) {
+            store.set('options.openLinksInternally', e.checked);
+          },
+          checked: store.get('options.openLinksInternally')
+          ? store.get('options.openLinksInternally')
+          : false
+        },
+        {
           label: 'Enabled Services',
           submenu: enabledServicesMenuItems
         },


### PR DESCRIPTION
I added an option for sites that have <a> tags with target="_blank", links can be opened in current window instead of creating a new window instance (an example is https://bilibili.com). This should be the expected behavior for a desktop app. Off by default.

- fix #105